### PR TITLE
Multiple proposed values per ballot, choose 'latest' one

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: "Model check"
 on:
   pull_request:
   push:
+    branches:
+      master
 
 jobs:
   tests:

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 **.toolbox
-states
+**/states

--- a/MultiPaxos/MC.cfg
+++ b/MultiPaxos/MC.cfg
@@ -2,7 +2,6 @@
 CONSTANTS
 v1 = v1
 v2 = v2
-v3 = v3
 \* MV CONSTANT declarations
 CONSTANTS
 a1 = a1

--- a/MultiPaxos/MC.cfg
+++ b/MultiPaxos/MC.cfg
@@ -2,6 +2,7 @@
 CONSTANTS
 v1 = v1
 v2 = v2
+v3 = v3
 \* MV CONSTANT declarations
 CONSTANTS
 a1 = a1

--- a/MultiPaxos/MC.cfg
+++ b/MultiPaxos/MC.cfg
@@ -9,18 +9,18 @@ a2 = a2
 a3 = a3
 \* MV CONSTANT definitions
 CONSTANT
-Values <- const_16285966784012000
+Values <- const_1629302032521219000
 \* MV CONSTANT definitions
 CONSTANT
-Acceptors <- const_16285966784013000
+Acceptors <- const_1629302032521220000
 \* SYMMETRY definition
-SYMMETRY symm_16285966784014000
+SYMMETRY symm_1629302032521221000
 \* CONSTANT definitions
 CONSTANT
-Ballots <- const_16285966784015000
+Ballots <- const_1629302032521222000
 \* CONSTANT definitions
 CONSTANT
-Quorums <- const_16285966784016000
+Quorums <- const_1629302032521223000
 \* SPECIFICATION definition
 SPECIFICATION
 Spec
@@ -28,4 +28,4 @@ Spec
 INVARIANT
 TypeInvariant
 Consistency
-\* Generated on Tue Aug 10 12:57:58 BST 2021
+\* Generated on Wed Aug 18 16:53:52 BST 2021

--- a/MultiPaxos/MC.tla
+++ b/MultiPaxos/MC.tla
@@ -12,30 +12,30 @@ a1, a2, a3
 ----
 
 \* MV CONSTANT definitions Values
-const_16285966784012000 == 
+const_1629302032521219000 == 
 {v1, v2}
 ----
 
 \* MV CONSTANT definitions Acceptors
-const_16285966784013000 == 
+const_1629302032521220000 == 
 {a1, a2, a3}
 ----
 
 \* SYMMETRY definition
-symm_16285966784014000 == 
-Permutations(const_16285966784012000) \union Permutations(const_16285966784013000)
+symm_1629302032521221000 == 
+Permutations(const_1629302032521219000) \union Permutations(const_1629302032521220000)
 ----
 
 \* CONSTANT definitions @modelParameterConstants:0Ballots
-const_16285966784015000 == 
+const_1629302032521222000 == 
 {1,2}
 ----
 
 \* CONSTANT definitions @modelParameterConstants:1Quorums
-const_16285966784016000 == 
+const_1629302032521223000 == 
 {{a1,a2},{a2,a3},{a3,a1}}
 ----
 
 =============================================================================
 \* Modification History
-\* Created Tue Aug 10 12:57:58 BST 2021 by cjen1
+\* Created Wed Aug 18 16:53:52 BST 2021 by cjen1

--- a/MultiPaxos/MC.tla
+++ b/MultiPaxos/MC.tla
@@ -3,7 +3,7 @@ EXTENDS MultiPaxos, TLC
 
 \* MV CONSTANT declarations@modelParameterConstants
 CONSTANTS
-v1, v2
+v1, v2, v3
 ----
 
 \* MV CONSTANT declarations@modelParameterConstants
@@ -28,7 +28,7 @@ Permutations(const_16285966784012000) \union Permutations(const_1628596678401300
 
 \* CONSTANT definitions @modelParameterConstants:0Ballots
 const_16285966784015000 == 
-{1,2}
+{1,2,3,4}
 ----
 
 \* CONSTANT definitions @modelParameterConstants:1Quorums

--- a/MultiPaxos/MC.tla
+++ b/MultiPaxos/MC.tla
@@ -3,7 +3,7 @@ EXTENDS MultiPaxos, TLC
 
 \* MV CONSTANT declarations@modelParameterConstants
 CONSTANTS
-v1, v2, v3
+v1, v2
 ----
 
 \* MV CONSTANT declarations@modelParameterConstants
@@ -28,7 +28,7 @@ Permutations(const_16285966784012000) \union Permutations(const_1628596678401300
 
 \* CONSTANT definitions @modelParameterConstants:0Ballots
 const_16285966784015000 == 
-{1,2,3,4}
+{1,2}
 ----
 
 \* CONSTANT definitions @modelParameterConstants:1Quorums

--- a/MultiPaxos/MultiPaxos.tla
+++ b/MultiPaxos/MultiPaxos.tla
@@ -6,8 +6,8 @@ CONSTANTS Ballots, Acceptors, Values, Quorums
 
 VARIABLES   msgs,
             acc,
-	    prop,
-	    commits
+            prop,
+            commits
 
 \* a =< b
 Prefix(a,b) ==
@@ -29,8 +29,8 @@ PossibleValues == AllSeqFromSet(Values)
 
 Messages ==      [type : {"1a"}, bal : Ballots]
             \cup [type : {"1b"}, bal : Ballots, 
-	            maxVBal : Ballots \cup {-1}, maxVal : PossibleValues, maxPC : Nat,
-		    acc : Acceptors]
+                    maxVBal : Ballots \cup {-1}, maxVal : PossibleValues, maxPC : Nat,
+                    acc : Acceptors]
             \cup [type : {"2a"}, bal : Ballots, val : PossibleValues, pc : Nat]
             \cup [type : {"2b"}, bal : Ballots, val : PossibleValues, acc : Acceptors, pc : Nat]
 
@@ -38,14 +38,14 @@ ProposerState == [val : PossibleValues, counter : Nat]
 
 AcceptorState == [maxBal : Ballots \cup {-1},
                   maxVBal: Ballots \cup {-1},
-		  maxVal : PossibleValues,
-		  maxPC : Nat]
+                  maxVal : PossibleValues,
+                  maxPC : Nat]
 
 TypeInvariant == /\ msgs \in SUBSET Messages
-		 /\ acc \in [Acceptors -> AcceptorState]
+                 /\ acc \in [Acceptors -> AcceptorState]
                  /\ \A a \in Acceptors : acc[a].maxBal >= acc[a].maxVBal
-		 /\ prop \in [Ballots -> ProposerState]
-		 /\ \A v \in Range(commits) : v \in [bal : Ballots, val : PossibleValues]
+                 /\ prop \in [Ballots -> ProposerState]
+                 /\ \A v \in Range(commits) : v \in [bal : Ballots, val : PossibleValues]
 
 vars == <<msgs, acc, prop, commits>>
 
@@ -53,9 +53,9 @@ vars == <<msgs, acc, prop, commits>>
 
 Init == /\ msgs = {}
         /\ acc = [a \in Acceptors |-> 
-	           [maxVBal |-> -1, maxBal |-> -1, maxVal |-> << >>, maxPC |-> 0]]
-	/\ prop = [b \in Ballots |-> [val |-> << >>, counter |-> 0]]
-	/\ commits = << >>
+                   [maxVBal |-> -1, maxBal |-> -1, maxVal |-> << >>, maxPC |-> 0]]
+        /\ prop = [b \in Ballots |-> [val |-> << >>, counter |-> 0]]
+        /\ commits = << >>
 
 Send(m) == msgs' = msgs \cup {m}
 
@@ -91,12 +91,12 @@ Phase2a(b) ==
          postfixOptions == {<<>>} \cup {<<v>> : v \in Values \ Range(prefix)}
      IN \E v \in postfixOptions:
           LET val == prefix \o v
-	      pc == prop[b].counter + 1
-	      msg == [type |-> "2a", bal |-> b, val |-> val, pc |-> pc]
-	  IN 
+              pc == prop[b].counter + 1
+              msg == [type |-> "2a", bal |-> b, val |-> val, pc |-> pc]
+          IN 
           /\ ~\E m \in msgs: m.type = "2a" /\ m.bal = b /\ m.val = val
           /\ Send(msg)
-	  /\ prop' = [prop EXCEPT ![b] = [val |-> val, counter |-> pc]]
+          /\ prop' = [prop EXCEPT ![b] = [val |-> val, counter |-> pc]]
   /\ UNCHANGED << acc, commits >>
 
 Phase2b(a) ==
@@ -113,20 +113,21 @@ Phase2b(a) ==
 \*   and then the largest common prefix of those msgs
 Commit(b) ==
   /\ QuorumExists(msgs, b, "2b")
-  /\ LET ms == {m \in msgs: m.type = "2b" /\ m.bal = b}
-         LeqPC(ma,mb) == ma.pc =< mb.pc
-	 \* Just the newest message for each acceptor
+  /\ LET LeqPC(ma,mb) == ma.pc =< mb.pc
+         \* Every phase 2b message for this ballot
+         ms == {m \in msgs: m.type = "2b" /\ m.bal = b}
+         \* The newest message for each acceptor
          ams == {Max(LeqPC, {m \in ms: m.acc = a}): a \in {a \in Acceptors: \E m \in ms: m.acc = a}}
-	 relevantQuorums == {q \in Quorums: \A a \in q: \E m \in ams: m.acc = a}
-	 \* Index ams on acceptors
-	 fams(a) == CHOOSE m \in ams: m.acc = a
-	 \* The messages for each quorum
-	 qams == {{fams(a): a \in q} : q \in relevantQuorums}
-	 \* The value decided in each quorum
-	 qvs == {Min(Prefix, {m.val: m \in qms}): qms \in qams}
-	 \* The largest decided value
-	 v == Max(Prefix, qvs)
-	 commit == [bal |-> b, val |-> v]
+         relevantQuorums == {q \in Quorums: \A a \in q: \E m \in ams: m.acc = a}
+         \* Index ams on acceptors
+         fams(a) == CHOOSE m \in ams: m.acc = a
+         \* The messages for each quorum
+         qams == {{fams(a): a \in q} : q \in relevantQuorums}
+         \* The value decided in each quorum
+         qvs == {Min(Prefix, {m.val: m \in qms}): qms \in qams}
+         \* The largest decided value
+         v == Max(Prefix, qvs)
+         commit == [bal |-> b, val |-> v]
      IN /\ ~ commit \in Range(commits)
         /\ commits' = commits \o << commit >>
         /\ UNCHANGED << msgs, acc, prop >>

--- a/MultiPaxos/MultiPaxos.tla
+++ b/MultiPaxos/MultiPaxos.tla
@@ -7,8 +7,7 @@ CONSTANTS Ballots, Acceptors, Values, Quorums
 VARIABLES   msgs,
             maxBal,
             maxVBal,
-            maxVal,
-            propVal
+            maxVal
 
 \* a =< b
 Prefix(a,b) ==
@@ -35,10 +34,9 @@ TypeInvariant == /\ msgs \in SUBSET Messages
                  /\ maxVBal \in [Acceptors -> Ballots \cup {-1}]
                  /\ maxBal \in [Acceptors -> Ballots \cup {-1}]
                  /\ maxVal \in [Acceptors -> PossibleValues]
-                 /\ propVal \in [Ballots -> PossibleValues]
                  /\ \A a \in Acceptors : maxBal[a] >= maxVBal[a]
 
-vars == <<msgs, maxBal, maxVBal, maxVal, propVal>>
+vars == <<msgs, maxBal, maxVBal, maxVal>>
 
 -----------------------------------------------------------------------------
 
@@ -46,14 +44,13 @@ Init == /\ msgs = {}
         /\ maxVBal = [a \in Acceptors |-> -1]
         /\ maxBal = [a \in Acceptors |-> -1]
         /\ maxVal = [a \in Acceptors |-> << >>]
-        /\ propVal = [b \in Ballots |-> << >>]
 
 Send(m) == msgs' = msgs \cup {m}
 
 Phase1a(b) == 
-  /\ ~ \E m \in msgs : (m.type = "1a") /\ (m.bal = b)
+\*  /\ ~ \E m \in msgs : (m.type = "1a") /\ (m.bal = b)
   /\ Send ([type |-> "1a", bal |-> b])
-  /\ UNCHANGED <<maxVBal, maxBal, maxVal, propVal>>
+  /\ UNCHANGED <<maxVBal, maxBal, maxVal>>
 
 Phase1b(a) ==
   \E m \in msgs :
@@ -62,7 +59,7 @@ Phase1b(a) ==
     /\ Send([type |-> "1b", bal |-> m.bal, maxVBal |-> maxVBal[a],
                 maxVal |-> maxVal[a], acc |-> a])
     /\ maxBal' = [maxBal EXCEPT ![a] = m.bal]
-    /\ UNCHANGED <<maxVBal, maxVal, propVal>>
+    /\ UNCHANGED <<maxVBal, maxVal>>
 
 QuorumExists(s, b, type) ==
   \E Q \in Quorums:
@@ -75,29 +72,12 @@ ValueSelect(b) ==
       m == CHOOSE m \in r : ~\E m1 \in r : ~Prefix(m1.maxVal, m.maxVal)
   IN m.maxVal
 
-Send2a(b, msg) ==
-  /\ ~ \E m \in msgs : m = msg
-  /\ Prefix(propVal[b], msg.val)
-  /\ propVal' = [propVal EXCEPT ![b] = msg.val]
-  /\ Send(msg)
-
-ProposeNewValue(b, prefix) == 
-  /\ \E v \in Values : ~ v \in Range(prefix)
-  /\ LET v == CHOOSE v \in Values : ~ v \in Range(prefix)
-         val == prefix \o <<v>>
-         msg == [type |-> "2a", bal |-> b, val |-> val]
-     IN Send2a(b, msg)
-
-ProposePrefix(b, val) ==
-  Send2a(b, [type |-> "2a", bal |-> b, val |-> val]) 
-
 Phase2a(b) ==
   /\ QuorumExists(msgs, b, "1b")
-  /\ LET prefix1a == ValueSelect(b)
-         prefixProp == propVal[b]
-         prefix == IF Prefix(prefix1a, prefixProp) THEN prefixProp ELSE prefix1a
-     IN \/ ProposeNewValue(b, prefix)
-        \/ ProposePrefix(b, prefix)
+  /\ ~ \E m \in msgs : m.type = "2a" /\ m.bal = b
+  /\ LET prefix == ValueSelect(b)
+     IN \E vs \in AllSeqFromSet(Values \ Range(prefix)):
+        Send([type |-> "2a", bal |-> b, val |-> prefix \o vs])
   /\ UNCHANGED <<maxBal, maxVBal, maxVal>>
 
 Phase2b(a) ==
@@ -109,30 +89,32 @@ Phase2b(a) ==
     /\ maxVBal' = [maxVBal EXCEPT ![a] = m.bal]
     /\ maxBal'  = [maxBal EXCEPT ![a] = m.bal]
     /\ maxVal'  = [maxVal EXCEPT ![a] = m.val]
-    /\ UNCHANGED <<propVal>>
 
 Next == \/ \E b \in Ballots   : Phase1a(b) \/ Phase2a(b)
         \/ \E a \in Acceptors : Phase1b(a) \/ Phase2b(a)
 
 Spec == Init /\ [][Next]_vars
 
-\* A prefix is committed if a p2 quorum exists of responses where it is a prefix
-\* Thus this is the set of values which could be committed within a ballot number
-\*   Hence we form the set of possible quorums
-\*   And find the largest prefix they could be used to commit (ie the smallest value in those messages)
-ValueCommits(b) ==
-  LET qms == LET ms == SUBSET {m \in msgs : (m.type = "2b") /\ (m.bal = b)}
-             IN {s \in ms: QuorumExists(s, b, "2b")}
-      minV(q) == LET vs == {m.val : m \in q} IN CHOOSE v \in vs: \A v1 \in vs: Prefix(v, v1)
-  IN {minV(q): q \in qms}
 
+(*
+ * Take the longest decided value for a given ballot number
+ *    By taking all possible quorums
+ *    Taking the largest common prefix for each quorum (decided value)
+ *    Taking the largest decided log
+*)
+DecidedValues(b) ==
+  LET ms == {m \in msgs : (m.type = "2b") /\ (m.bal = b)}
+  IN IF ~QuorumExists(ms, b, "2b")
+     THEN {}
+     ELSE {m.val : m \in ms}
+     
 \* Consistency is satisified if for all values that could be committed in a ballot,
 \*   for each subsequent ballot, every value they could commit has the first value as a prefix
 \* i.e. if you commit a list, it will be a prefix of all other committed lists
 Consistency ==
   \A b1, b2 \in Ballots : 
-    b1 < b2 => \A v1 \in ValueCommits(b1): 
-               \A v2 \in ValueCommits(b2):
-          	         Prefix(v1, v2)
-
+    b1 < b2 
+    => \A v1 \in DecidedValues(b1):
+       \A v2 \in DecidedValues(b2):
+       Prefix(v1, v2)
 =============================================================================

--- a/Paxos/MC.cfg
+++ b/Paxos/MC.cfg
@@ -1,0 +1,31 @@
+\* MV CONSTANT declarations
+CONSTANTS
+v1 = v1
+v2 = v2
+\* MV CONSTANT declarations
+CONSTANTS
+a1 = a1
+a2 = a2
+a3 = a3
+\* MV CONSTANT definitions
+CONSTANT
+Values <- const_1629302032521219000
+\* MV CONSTANT definitions
+CONSTANT
+Acceptors <- const_1629302032521220000
+\* SYMMETRY definition
+SYMMETRY symm_1629302032521221000
+\* CONSTANT definitions
+CONSTANT
+Ballots <- const_1629302032521222000
+\* CONSTANT definitions
+CONSTANT
+Quorums <- const_1629302032521223000
+\* SPECIFICATION definition
+SPECIFICATION
+Spec
+\* INVARIANT definition
+INVARIANT
+TypeInvariant
+Consistency
+\* Generated on Wed Aug 18 16:53:52 BST 2021

--- a/Paxos/MC.tla
+++ b/Paxos/MC.tla
@@ -1,0 +1,41 @@
+---- MODULE MC ----
+EXTENDS Paxos, TLC
+
+\* MV CONSTANT declarations@modelParameterConstants
+CONSTANTS
+v1, v2
+----
+
+\* MV CONSTANT declarations@modelParameterConstants
+CONSTANTS
+a1, a2, a3
+----
+
+\* MV CONSTANT definitions Values
+const_1629302032521219000 == 
+{v1, v2}
+----
+
+\* MV CONSTANT definitions Acceptors
+const_1629302032521220000 == 
+{a1, a2, a3}
+----
+
+\* SYMMETRY definition
+symm_1629302032521221000 == 
+Permutations(const_1629302032521219000) \union Permutations(const_1629302032521220000)
+----
+
+\* CONSTANT definitions @modelParameterConstants:0Ballots
+const_1629302032521222000 == 
+{1,2}
+----
+
+\* CONSTANT definitions @modelParameterConstants:1Quorums
+const_1629302032521223000 == 
+{{a1,a2},{a2,a3},{a3,a1}}
+----
+
+=============================================================================
+\* Modification History
+\* Created Wed Aug 18 16:53:52 BST 2021 by cjen1


### PR DESCRIPTION
This PR adds the following to MultiPaxos.

- Explicit commit option
  - Consistency based on commits
- Multiple proposed values per ballot
- Leader ensures that propoosed values only increase (from its perspective)
- Acceptors keep the 'newest' (from the proposer's perspective) ballot