### PR TITLE
Add unreliable communications

### DIFF
--- a/MultiPaxos/MC.cfg
+++ b/MultiPaxos/MC.cfg
@@ -9,23 +9,25 @@ a2 = a2
 a3 = a3
 \* MV CONSTANT definitions
 CONSTANT
-Values <- const_1629302032521219000
+Values <- const_163102845479584000
 \* MV CONSTANT definitions
 CONSTANT
-Acceptors <- const_1629302032521220000
+Acceptors <- const_163102845479585000
 \* SYMMETRY definition
-SYMMETRY symm_1629302032521221000
+SYMMETRY symm_163102845479586000
 \* CONSTANT definitions
 CONSTANT
-Ballots <- const_1629302032521222000
+Ballots <- const_163102845479587000
 \* CONSTANT definitions
 CONSTANT
-Quorums <- const_1629302032521223000
+Quorums <- const_163102845479588000
 \* SPECIFICATION definition
 SPECIFICATION
 Spec
 \* INVARIANT definition
 INVARIANT
-TypeInvariant
-Consistency
-\* Generated on Wed Aug 18 16:53:52 BST 2021
+InterBalConsistency
+\* PROPERTY definition
+PROPERTY
+IntraBalConsistency_property
+\* Generated on Tue Sep 07 16:27:34 BST 2021

--- a/MultiPaxos/MC.tla
+++ b/MultiPaxos/MC.tla
@@ -12,30 +12,30 @@ a1, a2, a3
 ----
 
 \* MV CONSTANT definitions Values
-const_1629302032521219000 == 
+const_163102845479584000 == 
 {v1, v2}
 ----
 
 \* MV CONSTANT definitions Acceptors
-const_1629302032521220000 == 
+const_163102845479585000 == 
 {a1, a2, a3}
 ----
 
 \* SYMMETRY definition
-symm_1629302032521221000 == 
-Permutations(const_1629302032521219000) \union Permutations(const_1629302032521220000)
+symm_163102845479586000 == 
+Permutations(const_163102845479584000) \union Permutations(const_163102845479585000)
 ----
 
 \* CONSTANT definitions @modelParameterConstants:0Ballots
-const_1629302032521222000 == 
+const_163102845479587000 == 
 {1,2}
 ----
 
 \* CONSTANT definitions @modelParameterConstants:1Quorums
-const_1629302032521223000 == 
+const_163102845479588000 == 
 {{a1,a2},{a2,a3},{a3,a1}}
 ----
 
 =============================================================================
 \* Modification History
-\* Created Wed Aug 18 16:53:52 BST 2021 by cjen1
+\* Created Tue Sep 07 16:27:34 BST 2021 by cjjen

--- a/MultiPaxos/MultiPaxos.tla
+++ b/MultiPaxos/MultiPaxos.tla
@@ -6,8 +6,7 @@ CONSTANTS Ballots, Acceptors, Values, Quorums
 
 VARIABLES   msgs,
             acc,
-            prop,
-            commits
+            prop
 
 \* a =< b
 Prefix(a,b) ==
@@ -34,34 +33,36 @@ Messages ==      [type : {"1a"}, bal : Ballots]
             \cup [type : {"2a"}, bal : Ballots, val : PossibleValues]
             \cup [type : {"2b"}, bal : Ballots, val : PossibleValues, acc : Acceptors]
 
-ProposerState == [val : PossibleValues]
+ProposerState == [val : PossibleValues,
+                  valSelect : {TRUE, FALSE},
+		  committed : PossibleValues,
+		  hasCommitted : {TRUE,FALSE}]
 
 AcceptorState == [maxBal : Ballots \cup {-1},
                   maxVBal: Ballots \cup {-1},
                   maxVal : PossibleValues]
 
+
 TypeInvariant == /\ msgs \in SUBSET Messages
                  /\ acc \in [Acceptors -> AcceptorState]
                  /\ \A a \in Acceptors : acc[a].maxBal >= acc[a].maxVBal
                  /\ prop \in [Ballots -> ProposerState]
-                 /\ \A v \in Range(commits) : v \in [bal : Ballots, val : PossibleValues]
 
-vars == <<msgs, acc, prop, commits>>
+vars == <<msgs, acc, prop>>
 
 -----------------------------------------------------------------------------
 
 Init == /\ msgs = {}
-        /\ acc = [a \in Acceptors |-> 
-                   [maxVBal |-> -1, maxBal |-> -1, maxVal |-> << >> ]]
-        /\ prop = [b \in Ballots |-> [val |-> << >>]]
-        /\ commits = << >>
+        /\ acc  = [a \in Acceptors |-> 
+                    [maxVBal |-> -1, maxBal |-> -1, maxVal |-> << >> ]]
+        /\ prop = [b \in Ballots |-> [val |-> << >>, valSelect |-> FALSE, committed |-> <<>>, hasCommitted |-> FALSE]]
 
 Send(m) == msgs' = msgs \cup {m}
 
 Phase1a(b) == 
   /\ ~\E m \in msgs: m.type = "1a" /\ m.bal = b
   /\ Send ([type |-> "1a", bal |-> b])
-  /\ UNCHANGED << acc, prop, commits >>
+  /\ UNCHANGED << acc, prop >>
 
 Phase1b(a) ==
   \E m \in msgs :
@@ -70,34 +71,28 @@ Phase1b(a) ==
     /\ Send([type |-> "1b", acc |-> a, 
              bal |-> m.bal, maxVBal |-> acc[a].maxVBal, maxVal |-> acc[a].maxVal])
     /\ acc' = [acc EXCEPT ![a] = [acc[a] EXCEPT !.maxBal = m.bal]]
-    /\ UNCHANGED << prop, commits >>
+    /\ UNCHANGED << prop >>
 
 ValueSelect(b) ==
-  LET ms == {m \in msgs : m.type = "1b" /\ m.bal = b}
-      maxBalNum == Max(LAMBDA x,y: x <= y, {m.maxVBal: m \in ms})
-      maxValMsg == Max(LAMBDA x,y: Prefix(x.maxVal, y.maxVal), {m \in ms: m.maxVBal = maxBalNum})
-  IN maxValMsg.maxVal
+  /\ ~ prop[b].valSelect
+  /\ \E Q \in Quorums, S \in SUBSET {m \in msgs: (m.type = "1b") /\ (m.bal = b)}:
+       /\ \A a \in Q: \E m \in S: m.acc = a
+       /\ LET maxBalNum == Max(LAMBDA x,y: x <= y, {m.maxVBal: m \in S})
+              maxValMsg == Max(LAMBDA x,y: Prefix(x.maxVal, y.maxVal), {m \in S: m.maxVBal = maxBalNum})
+          IN  /\ prop' = [prop EXCEPT ![b] = 
+	                          [prop[b] EXCEPT !.val = maxValMsg.maxVal, !.valSelect = TRUE]]
+	      /\ UNCHANGED << acc, msgs >>
 
 Phase2a(b) ==
-  /\ \E Q \in Quorums: 
-     \A a \in Q: 
-     \E m \in msgs: /\ m.type = "1b"
-                    /\ m.acc = a
-		    /\ m.bal = b
-  /\ LET prefix == IF \E m \in msgs:
-                        /\ m.type = "2a"
-			/\ m.bal = b
-		   THEN prop[b].val 
-		   ELSE ValueSelect(b)
-         possibleAppends == {<<>>} \cup {<<v>> : v \in Values \ Range(prefix)}
-     IN \E v \in possibleAppends:
-          LET val == prefix \o v
-              msg == [type |-> "2a", bal |-> b, val |-> val]
-          IN 
-          /\ ~\E m \in msgs: m.type = "2a" /\ m.bal = b /\ m.val = val
-          /\ Send(msg)
-          /\ prop' = [prop EXCEPT ![b] = [val |-> val]]
-  /\ UNCHANGED << acc, commits >>
+  /\ prop[b].valSelect
+  /\ \E v \in {<<>>} \cup {<<v>> : v \in Values \ Range(prop[b].val)}:
+        LET val == prop[b].val \o v
+            msg == [type |-> "2a", bal |-> b, val |-> val]
+        IN 
+        /\ ~\E m \in msgs: m.type = "2a" /\ m.bal = b /\ m.val = val
+        /\ Send(msg)
+        /\ prop' = [prop EXCEPT ![b] = [prop[b] EXCEPT !.val = val]]
+  /\ UNCHANGED << acc >>
 
 Phase2b(a) ==
   /\ \E m \in msgs :
@@ -107,34 +102,34 @@ Phase2b(a) ==
             /\ Prefix(acc[a].maxVal, m.val)
       /\ Send([type |-> "2b", bal |-> m.bal, val |-> m.val, acc |-> a])
       /\ acc' = [acc EXCEPT ![a] = [maxBal |-> m.bal, maxVBal |-> m.bal, maxVal |-> m.val]]
-  /\ UNCHANGED << prop, commits >>
+  /\ UNCHANGED << prop >>
 
 Commit(b) ==
-  LET quorumExists(v) == \E q \in Quorums:
-                         \A a \in q:
-			 \E m \in msgs: 
-			   /\ m.type = "2b" 
-			   /\ m.bal = b 
-			   /\ m.acc = a
-			   /\ Prefix(v, m.val)
-      commitable == {v \in PossibleValues: quorumExists(v)}
-  IN \E v \in commitable:
-       LET commit == [bal |-> b, val |-> v]
-       IN
-       /\ \A v1 \in commitable: Prefix(v1, v)
-       /\ ~ commit \in Range(commits)
-       /\ commits' = commits \o << commit >>
-       /\ UNCHANGED << msgs, acc, prop >>
+  \E Q \in Quorums: 
+  \E S \in SUBSET {m \in msgs: /\ m.type = "2b" 
+                               /\ m.bal = b 
+       		               /\ m.acc \in Q}:
+     /\ \A a \in Q: \E m \in S: m.acc = a
+     /\ LET val == Min(Prefix, {m.val: m \in S})
+        IN /\ Prefix(prop[b].committed, val)
+           /\ \A m \in S: \A m1 \in S \ {m}: m.acc /= m1.acc
+           /\ prop' = [prop EXCEPT ![b] = [prop[b] EXCEPT !.committed = val, !.hasCommitted = TRUE]]
+           /\ UNCHANGED << msgs, acc >>
 
-Next == \/ \E b \in Ballots   : Phase1a(b) \/ Phase2a(b) \/ Commit(b)
+Next == \/ \E b \in Ballots   : Phase1a(b) \/ ValueSelect(b) \/ Phase2a(b) \/ Commit(b)
         \/ \E a \in Acceptors : Phase1b(a) \/ Phase2b(a)
 
 Spec == Init /\ [][Next]_vars
 
-Consistency ==
-  \A i, j \in DOMAIN(commits):
-    /\ i < j
-    /\ commits[i].bal <= commits[j].bal
-    => Prefix(commits[i].val, commits[j].val)
+InterBalConsistency ==
+  \A b1, b2 \in Ballots: 
+  LET v1 == prop[b1].committed
+      v2 == prop[b2].committed
+  IN (b1 < b2 /\ prop[b1].hasCommitted /\ prop[b2].hasCommitted) => Prefix(v1, v2)
+
+IntraBalConsistency ==
+  \A b \in Ballots: Prefix(prop[b].committed, prop'[b].committed)
+IntraBalConsistency_property ==
+  [] [IntraBalConsistency]_prop
 
 =============================================================================


### PR DESCRIPTION
Add unreliable communications to phase 2a

Remove explicit commit log (it caused a larger state expansion in TLC).
Use a temporal formula on pairs of states for intra-ballot consistency.

Split out ValueSelect from Phase 2a into two actions.
This increases the number of actions but simplifies both.

