### PR TITLE
Remove explicit commit

### DIFF
--- a/MultiPaxos/MC.cfg
+++ b/MultiPaxos/MC.cfg
@@ -26,8 +26,8 @@ SPECIFICATION
 Spec
 \* INVARIANT definition
 INVARIANT
-BetweenBallotConsistency
+Consistency
 \* PROPERTY definition
-PROPERTY
-prop_1631037570427206000
+\*PROPERTY
+\*prop_1631037570427206000
 \* Generated on Tue Sep 07 18:59:30 BST 2021

--- a/MultiPaxos/MC.tla
+++ b/MultiPaxos/MC.tla
@@ -37,8 +37,8 @@ const_1631037570427204000 ==
 ----
 
 \* PROPERTY definition @modelCorrectnessProperties:0
-prop_1631037570427206000 ==
-[][InsideBallotConsistency]_prop
+\*prop_1631037570427206000 ==
+\*[][InsideBallotConsistency]_prop
 ----
 =============================================================================
 \* Modification History


### PR DESCRIPTION
This PR removes the explicit Commit phase, and in doing so transforms the consistency property to operate on the phase 2b messages from the acceptors.

@heidihoward Let me know if this is actually simpler.

The downside of it is that it makes it less clear when a log is committed, and also operates on a more MultiPaxos based argument. 

The upside is that it removes a relatively complicated (commit) phase3 action.